### PR TITLE
Fix batch script delayed expansion error

### DIFF
--- a/uninstall_lightsout.bat
+++ b/uninstall_lightsout.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal enabledelayedexpansion
 REM Lights Out Mod - Uninstallation Script
 REM This script removes the Lights Out Halloween mod files from Rocket League
 


### PR DESCRIPTION
## Background
The `uninstall_lightsout.bat` script was failing with an unexpected token error due to improper handling of delayed variable expansion.

## Changes
- Added `setlocal enabledelayedexpansion` to the top of `uninstall_lightsout.bat`. This enables delayed expansion for variables enclosed in `!`, which is used extensively in the script's subroutines.

## Testing
- [ ] Run `uninstall_lightsout.bat` to ensure no errors occur.
- [ ] Verify that the script successfully uninstalls the mod.
